### PR TITLE
Updating dependencies to address RUSTSEC-2023-0052

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ async-h1 = {version="2.3",optional=true}
 http-types = {version="2.11",optional=true}
 
 hyper = { version = "0.14", optional=true }
-serde_qs = { version ="0.9", optional=true }
+serde_qs = { version ="0.12.0", optional=true }
 serde_urlencoded = { version ="0.7", optional=true }
 serde_json = {version="1.0",optional=true}
 tokio = {version = "1.6", optional=true}
@@ -32,14 +32,14 @@ log = "0.4"
 serde = "1.0"
 #pin-project = "1.0"
 
-futures-rustls = {version="0.22.0",optional=true}
-tokio-rustls = { version = "0.23.0", optional = true }
-webpki-roots = {version="0.22.0",optional=true}
+futures-rustls = {version="0.24.0",optional=true}
+tokio-rustls = { version = "0.24.1", optional = true }
+webpki-roots = {version="0.25.2",optional=true}
 #rustls-native-certs
 
-async-native-tls = { version = "0.4", default-features = false, optional = true }
+async-native-tls = { version = "0.5.0", default-features = false, optional = true }
 
-cookie_store = { version = "0.16.0", optional = true }
+cookie_store = { version = "0.20.0", optional = true }
 
 [features]
 use_hyper = ["tokio/net", "hyper/http1", "hyper/http2", "hyper/client", "hyper/runtime", "serde_qs", "serde_urlencoded","serde_json"]

--- a/src/tcp/mod.rs
+++ b/src/tcp/mod.rs
@@ -169,7 +169,7 @@ fn get_tls_connector() -> io::Result<TlsConnector>{
     #[cfg(feature = "rustls")]
     {
         let mut root_store = RootCertStore::empty();
-        root_store.add_server_trust_anchors(TLS_SERVER_ROOTS.0.iter().map(|ta| {
+        root_store.add_trust_anchors(TLS_SERVER_ROOTS.iter().map(|ta| {
             OwnedTrustAnchor::from_subject_spki_name_constraints(
                 ta.subject,
                 ta.spki,


### PR DESCRIPTION
Only one code change was needed to fix a deprecation warning after upgrading these crates. The motivation for these upgrades are to get crates that depend on webpki to be updated to depend on rustls-webpki to address https://rustsec.org/advisories/RUSTSEC-2023-0052. Both webpki-roots and futures-rustls have released updates that use the new dependency.

I only consume this library via async-acme's usage, so I've only done the bare minimum of testing: checking that the various cargo test variations found in the workflows still pass.