### PR TITLE
feat: make http2 optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ use_web_sys = ["web-sys", "wasm-bindgen", "wasm-bindgen-futures", "js-sys"]
 
 http2 = ["hyper/http2"]
 cookies = ["cookie_store"]
-proxies = ["async-trait"]
+proxies = ["async-trait", "tokio/io-util"]
 
 rustls = ["futures-rustls", "tokio-rustls", "webpki-roots"]
 async_native_tls = ["use_async_h1","async-native-tls/runtime-async-std"]
@@ -59,7 +59,7 @@ default = []
 
 [dev-dependencies]
 async-std = "1.9.0"
-tokio = {version = "1.6.1", features=["rt", "net"]}
+tokio = {version = "1.6.1", features=["rt", "net", "io-util"]}
 serde = {version = "1.0", features=["derive"]}
 
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,10 +43,11 @@ cookie_store = { version = "0.21.0", optional = true }
 async-trait = { version = "0.1", optional = true }
 
 [features]
-use_hyper = ["tokio/net", "tokio/rt", "hyper/http1", "hyper/http2", "hyper/client", "serde_qs", "serde_urlencoded","serde_json"]
+use_hyper = ["tokio/net", "tokio/rt", "hyper/http1", "hyper/client", "serde_qs", "serde_urlencoded","serde_json"]
 use_async_h1 = ["async-std", "async-h1", "http-types"]
 use_web_sys = ["web-sys", "wasm-bindgen", "wasm-bindgen-futures", "js-sys"]
 
+http2 = ["hyper/http2"]
 cookies = ["cookie_store"]
 proxies = ["async-trait"]
 


### PR DESCRIPTION
In some space constrain devices such as embedded device we need to make the binary smallest as possible. This PR make http2 as feature for allowing reduce binary size some hundreds kB