### PR TITLE
chore: release v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.6.1](https://github.com/User65k/generic-async-http-client/compare/v0.6.0...v0.6.1) - 2025-01-18
+
+### Other
+
+- only offer h2 if it is enabled ([#12](https://github.com/User65k/generic-async-http-client/pull/12))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "generic-async-http-client"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["User65k <15049544+User65k@users.noreply.github.com>"]
 edition = "2021"
 


### PR DESCRIPTION
## 🤖 New release
* `generic-async-http-client`: 0.6.0 -> 0.6.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.6.1](https://github.com/User65k/generic-async-http-client/compare/v0.6.0...v0.6.1) - 2025-01-18

### Other

- only offer h2 if it is enabled ([#12](https://github.com/User65k/generic-async-http-client/pull/12))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).