### PR TITLE
chore: release v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2](https://github.com/User65k/generic-async-http-client/compare/v0.6.1...v0.6.2) - 2025-01-20
+
+### Other
+
+- Fips ([#14](https://github.com/User65k/generic-async-http-client/pull/14))
+
 ## [0.6.1](https://github.com/User65k/generic-async-http-client/compare/v0.6.0...v0.6.1) - 2025-01-18
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "generic-async-http-client"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["User65k <15049544+User65k@users.noreply.github.com>"]
 edition = "2021"
 


### PR DESCRIPTION
## 🤖 New release
* `generic-async-http-client`: 0.6.1 -> 0.6.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.6.2](https://github.com/User65k/generic-async-http-client/compare/v0.6.1...v0.6.2) - 2025-01-20

### Other

- Fips ([#14](https://github.com/User65k/generic-async-http-client/pull/14))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).