### PR TITLE
chore: release v0.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.4](https://github.com/User65k/generic-async-http-client/compare/v0.6.3...v0.6.4) - 2025-04-10
+
+### Other
+
+- Merge pull request #19 from User65k/mock
+- rename action
+- make the example work w/o runtime
+- response mocking
+- error
+
 ## [0.6.3](https://github.com/User65k/generic-async-http-client/compare/v0.6.2...v0.6.3) - 2025-03-01
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "generic-async-http-client"
-version = "0.6.3"
+version = "0.6.4"
 authors = ["User65k <15049544+User65k@users.noreply.github.com>"]
 edition = "2021"
 


### PR DESCRIPTION



## 🤖 New release

* `generic-async-http-client`: 0.6.3 -> 0.6.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.6.4](https://github.com/User65k/generic-async-http-client/compare/v0.6.3...v0.6.4) - 2025-04-10

### Other

- Merge pull request #19 from User65k/mock
- rename action
- make the example work w/o runtime
- response mocking
- error
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).